### PR TITLE
Add compression to parquet file

### DIFF
--- a/R/espn_mbb_01_pbp_creation.R
+++ b/R/espn_mbb_01_pbp_creation.R
@@ -147,7 +147,8 @@ mbb_pbp_games <- function(y) {
     )
     arrow::write_parquet(
       espn_df,
-      glue::glue("mbb/pbp/parquet/play_by_play_{y}.parquet")
+      glue::glue("mbb/pbp/parquet/play_by_play_{y}.parquet"),
+      compression = "zstd"
     )
 
     retry_rate <- purrr::rate_backoff(

--- a/R/espn_mbb_01_pbp_creation.R
+++ b/R/espn_mbb_01_pbp_creation.R
@@ -148,7 +148,8 @@ mbb_pbp_games <- function(y) {
     arrow::write_parquet(
       espn_df,
       glue::glue("mbb/pbp/parquet/play_by_play_{y}.parquet"),
-      compression = "zstd"
+      compression = "zstd",
+      compression_level = 22
     )
 
     retry_rate <- purrr::rate_backoff(


### PR DESCRIPTION
Added compression to write_parquet for pbp since file size was above limit.
I was not able to verify on my local machine due to disk space issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved data file compression for play-by-play exports using a more efficient compression method and higher compression level, reducing storage usage and improving transfer efficiency while preserving existing data and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->