### PR TITLE
feat(compile): officials fall back to json/final for zero-HTTP historical backfill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,16 @@ workflow `::error::` after all requested seasons finish. Whatever datasets
 succeeded are committed regardless (per-dataset `tryCatch` keeps partial
 output usable).
 
+## Python build (`python/mbb_data_build/`)
+
+A **parallel** polars implementation of the same compile (sdv-py #256 producers),
+added for a future cutover. It does NOT drive daily CI — the R scripts above still
+do. Full-frame parity-tested against the committed R oracle parquets. See
+`python/README.md` for the CLI (`uv run python -m mbb_data_build --dataset <k> -s
+<yr> -e <yr> [--publish|--dry-run]`) and `uv run pytest`. Release tags are the
+real `espn_mens_college_basketball_*` strings (NOT `espn_mbb_*`). Any ESPN parsing
+change belongs upstream in `sportsdataverse.mbb`, not here.
+
 ## Repo Layout
 
 ```

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,59 @@
+# mbb_data_build — Python season-assembly build
+
+A polars port of the `R/espn_mbb_*_creation.R` compile. It reshapes the sibling
+[`hoopR-mbb-raw`](https://github.com/sportsdataverse/hoopR-mbb-raw) per-game JSON
+into season-level parquet/csv + a manifest and (optionally) uploads them to the
+`espn_mens_college_basketball_*` release tags on
+[`sportsdataverse-data`](https://github.com/sportsdataverse/sportsdataverse-data).
+
+**Every reshape delegates to a `sportsdataverse.mbb` release producer** — this
+package is the season-assembly loop + I/O + publish glue, not the parsing. The R
+scripts remain the byte-parity oracle.
+
+```
+hoopR-mbb-raw ──(per-game JSON)──▶ mbb_data_build ──(release upload)──▶ sportsdataverse-data ──▶ hoopR::load_mbb_*()
+```
+
+This is a **parallel implementation** — the R pipeline (`scripts/daily_mbb_R_processor.sh`)
+still drives daily CI. Wiring this package into CI is a separate cutover.
+
+## Run
+
+```sh
+# from python/ ; needs uv (https://docs.astral.sh/uv/)
+uv sync
+uv run python -m mbb_data_build --dataset pbp -s 2025 -e 2025            # build one dataset locally
+uv run python -m mbb_data_build --dataset officials -s 2025 -e 2025 --dry-run   # build + show what would publish
+uv run python -m mbb_data_build --dataset officials -s 2025 -e 2025 --publish   # build + upload release assets
+uv run pytest -q                                                        # full-frame parity vs the committed R oracles
+```
+
+- `--dataset` — one of the registry keys (`pbp`, `team_box`, `player_box`,
+  `schedules`, `shots`, `rosters`, `player_season_stats`, `team_season_stats`,
+  `standings`, `game_rosters`, `officials`; **no draft** — MBB has none).
+- `-s`/`-e` — inclusive season range (end year: `2025` = the 2024-25 season).
+- `--raw-root` — sibling `hoopR-mbb-raw` checkout, or an HTTP base URL
+  (`HOOPR_MBB_RAW_ROOT` env is the default; a base URL reads over HTTP).
+- `--publish` uploads per-file with `--clobber` (never delete-then-recreate,
+  which would open a 404 window for live loaders). `--dry-run` builds without
+  uploading.
+
+## Dependency
+
+`sportsdataverse` is pinned to git `main` in `pyproject.toml` (`[tool.uv.sources]`)
+— the `helper_mbb_*` producers merged there in sdv-py #256.
+
+## Parity
+
+`tests/mbb_data_build/test_parity_*.py` build each dataset for a real season into
+a temp dir and assert full-frame equality against the committed R oracle parquet
+under `mbb/<dataset>/parquet/`. The build never writes into the committed `mbb/`
+tree during tests.
+
+Notes on two deliberate divergences the tests document:
+- `player_season_stats` iterates the identity-lookup athlete ids (R's
+  `names(identity_lookup)`), and excludes two athlete ids whose *oracle* identity
+  disagrees with its own source payload (guarded so the set can't silently grow).
+- `officials` fall back to `json/final` when the recent-only `game_rosters/json`
+  sidecar is absent (its `gameInfo.officials` block is byte-identical there),
+  which recovers pre-scrape seasons with zero HTTP.

--- a/python/mbb_data_build/__init__.py
+++ b/python/mbb_data_build/__init__.py
@@ -2,8 +2,9 @@
 
 Parity port of ``hoopR-mbb-data/R/espn_mbb_*_creation.R``. Reshapes the sibling
 ``hoopR-mbb-raw`` per-game JSON into season-level parquet/csv + manifest and
-publishes to the ``espn_mbb_*`` release tags. R is retained
-as the byte-parity oracle.
+publishes to the ``espn_mens_college_basketball_*`` release tags (MBB's tag
+prefix is the full league name, not ``espn_mbb_*``). R is retained as the
+byte-parity oracle.
 """
 
 __all__ = ["config", "ingest", "io", "build", "publish", "reshapers"]

--- a/python/mbb_data_build/reshapers.py
+++ b/python/mbb_data_build/reshapers.py
@@ -62,18 +62,13 @@ def pbp_reshaper(final: dict, *, season: int, game_id: int) -> pl.DataFrame:
 
 
 def player_box_reshaper(final: dict, *, season: int, game_id: int) -> pl.DataFrame:
-    """helper_mbb_player_box() delegates to the shared wbb_player_box.
-    _FINAL_ORDER tuple, which places ``active`` right after ``did_not_play``.
-    The R-released espn_mens_college_basketball_player_boxscores puts
-    ``active`` as the LAST column instead (confirmed against the real 2025
-    oracle -- no WBB oracle-backed test exists upstream to have caught this).
-    Reorder here rather than in sdv-py, since that tuple is shared with WBB
-    and this divergence has not been confirmed against a WBB oracle.
+    """helper_mbb_player_box() emits the MBB release column order natively.
+
+    The ``active``-last vs ``active``-mid-list WBB/MBB divergence is now
+    handled in sdv-py's ``mbb_player_box._MBB_FINAL_ORDER`` (confirmed against
+    both the real MBB and WBB 2025 oracles), so no reshaping is needed here.
     """
-    out = helper_mbb_player_box(final)
-    if "active" in out.columns and out.columns[-1] != "active":
-        out = out.select([c for c in out.columns if c != "active"] + ["active"])
-    return out
+    return helper_mbb_player_box(final)
 
 
 RESHAPERS: dict = {
@@ -161,8 +156,17 @@ def shots_builder(season: int, *, raw_root: Path, base: Path) -> pl.DataFrame:
     return shots_from_pbp(pl.read_parquet(p))
 
 
-def _sidecar_builder(subdir: str, helper) -> object:
-    """Per-game sidecar loop (R scripts 09/10): completed games, tryCatch skips."""
+def _sidecar_builder(subdir: str, helper, *, fallback_subdir: str | None = None) -> object:
+    """Per-game sidecar loop (R scripts 09/10): completed games, tryCatch skips.
+
+    ``fallback_subdir`` recovers a game from a second raw location when the
+    primary sidecar is absent. Used by officials: its ``gameInfo.officials``
+    block is byte-identical in the processed ``json/final`` summary (present for
+    ~10x more historical games than the ``game_rosters/json`` scrape: 137k vs
+    13k), so pre-scrape seasons compile officials with zero HTTP. Purely additive
+    -- for a game whose primary sidecar exists the fallback never fires, so
+    current-season output is unchanged.
+    """
 
     def _build(season: int, *, raw_root: Path, base: Path) -> pl.DataFrame:
         from mbb_data_build import ingest
@@ -170,6 +174,8 @@ def _sidecar_builder(subdir: str, helper) -> object:
         frames: list[pl.DataFrame] = []
         for gid in ingest.season_completed_game_ids(season, raw_root=raw_root):
             payload = ingest.read_final(gid, raw_root=raw_root, subdir=subdir)
+            if payload is None and fallback_subdir is not None:
+                payload = ingest.read_final(gid, raw_root=raw_root, subdir=fallback_subdir)
             if payload is None:
                 continue
             try:
@@ -197,7 +203,11 @@ def _officials_builder() -> object:
     # SAME game_rosters sidecar that backs helper_mbb_game_rosters.
     from sportsdataverse.mbb import helper_mbb_officials
 
-    return _sidecar_builder("game_rosters/json", helper_mbb_officials)
+    # Officials' gameInfo.officials block is identical in json/final (verified),
+    # so fall back there to recover pre-scrape seasons (game_rosters/json is
+    # recent-only). game_rosters itself does NOT fall back -- its json/final
+    # boxscore roster diverges (athlete_display_name), pending investigation.
+    return _sidecar_builder("game_rosters/json", helper_mbb_officials, fallback_subdir="json/final")
 
 
 def _per_entity_frames(


### PR DESCRIPTION
## What

Phase B "biggest lever" (first, safe slice). The officials sidecar builder read only `game_rosters/json` — a recent-only scrape (~13k games). Its `gameInfo.officials` block is **byte-identical** in the processed `json/final` summary (~137k games), so officials now fall back to `json/final` when the primary sidecar is absent. Pre-scrape seasons (MBB 2003–2024) compile officials with **zero HTTP**.

## Safety

- **Purely additive.** The fallback only fires when `game_rosters/json` is missing for a game; current seasons have it, so their output is unchanged. Parity suite: `test_parity_game_rosters.py` + `test_parity_season_datasets.py` still 7 passed.
- Verified `helper_mbb_officials` output is **identical** from `json/final` vs `game_rosters/json` on a shared game (3×7).

## Scope / follow-ups (NOT in this PR)

- **`game_rosters` does NOT fall back** — its `json/final` boxscore roster diverges on `athlete_display_name`; needs a separate look before repointing.
- The actual historical **build + release publish** (running the compile over 2003–2024 and uploading assets) is a separate, outward-facing step — not done here.
- The same REPOINT applies to WBB (`game_rosters` 2007–25) / WNBA (2002–23) in their repos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for the Python-based college basketball data build pipeline, including CLI usage, dataset options, season ranges, publishing, and dry-run workflows.
  * Documented dataset parity testing and release-tag conventions.

* **Bug Fixes**
  * Improved compatibility with older seasons by recovering officials data from an alternate source when needed.
  * Preserved player box-score output without unnecessary column reordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->