### PR TITLE
feat(compile): game_rosters also falls back to json/final for zero-HTTP backfill

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -54,6 +54,10 @@ Notes on two deliberate divergences the tests document:
 - `player_season_stats` iterates the identity-lookup athlete ids (R's
   `names(identity_lookup)`), and excludes two athlete ids whose *oracle* identity
   disagrees with its own source payload (guarded so the set can't silently grow).
-- `officials` fall back to `json/final` when the recent-only `game_rosters/json`
-  sidecar is absent (its `gameInfo.officials` block is byte-identical there),
-  which recovers pre-scrape seasons with zero HTTP.
+- `officials` and `game_rosters` fall back to `json/final` when the recent-only
+  `game_rosters/json` sidecar is absent, recovering pre-scrape seasons with zero
+  HTTP. `officials`' `gameInfo.officials` block is byte-identical there;
+  `game_rosters`' boxscore roster is structurally identical, diverging only on
+  occasional display-name formatting ("L.J. Cryer" vs "LJ Cryer"), and historical
+  seasons have no `game_rosters/json` oracle so `json/final` is authoritative.
+  The fallback is purely additive — current seasons keep using `game_rosters/json`.

--- a/python/mbb_data_build/reshapers.py
+++ b/python/mbb_data_build/reshapers.py
@@ -195,7 +195,15 @@ def _sidecar_builder(subdir: str, helper, *, fallback_subdir: str | None = None)
 def _game_rosters_builder() -> object:
     from sportsdataverse.mbb import helper_mbb_game_rosters
 
-    return _sidecar_builder("game_rosters/json", helper_mbb_game_rosters)
+    # Same zero-HTTP backfill as officials: fall back to json/final when the
+    # recent-only game_rosters/json scrape is absent. The boxscore roster is
+    # structurally identical there; the only observed divergence is occasional
+    # display-name formatting ("L.J. Cryer" vs "LJ Cryer", 1/31 on the checked
+    # game), and historical seasons have no game_rosters/json oracle, so
+    # json/final is the authoritative source for them.
+    return _sidecar_builder(
+        "game_rosters/json", helper_mbb_game_rosters, fallback_subdir="json/final"
+    )
 
 
 def _officials_builder() -> object:
@@ -205,8 +213,7 @@ def _officials_builder() -> object:
 
     # Officials' gameInfo.officials block is identical in json/final (verified),
     # so fall back there to recover pre-scrape seasons (game_rosters/json is
-    # recent-only). game_rosters itself does NOT fall back -- its json/final
-    # boxscore roster diverges (athlete_display_name), pending investigation.
+    # recent-only) -- same json/final fallback as game_rosters above.
     return _sidecar_builder("game_rosters/json", helper_mbb_officials, fallback_subdir="json/final")
 
 


### PR DESCRIPTION
Follow-on to the officials fallback (#7), completing Phase B's "biggest lever" for MBB.

## Investigation resolved

The earlier `json/final` vs `game_rosters/json` game_rosters divergence turned out to be **a single cosmetic row**: `"L.J. Cryer"` vs `"LJ Cryer"` (ESPN's two display-name formats), 1/31 on the checked game. The roster is otherwise structurally identical — `athlete_id`, positions, and every other column match.

## Change

`game_rosters` now uses the same **additive** `json/final` fallback as officials:
- Current seasons keep reading `game_rosters/json` (fallback never fires) → parity suite still **7 passed**.
- Pre-scrape seasons (MBB 2003–2024) compile `game_rosters` with **zero HTTP**; historical seasons have no `game_rosters/json` oracle, so `json/final` is authoritative.

README parity note updated to cover both officials and game_rosters.