### PR TITLE
feat(ci): python mbb_data_build processor + opt-in workflow selector (cutover groundwork)

### DIFF
--- a/.github/workflows/daily_mbb.yml
+++ b/.github/workflows/daily_mbb.yml
@@ -18,6 +18,11 @@ on:
         required: false
         description: "End Year (e.g., 2023)"
         type: string
+      use_python_build:
+        required: false
+        description: "Use the python mbb_data_build processor instead of R (default: R)"
+        type: boolean
+        default: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -55,6 +60,11 @@ jobs:
             sportsdataverse/hoopR
             sportsdataverse/sportsdataverse-data
             ropensci/piggyback
+      - name: Set up uv (for the python build)
+        uses: astral-sh/setup-uv@v5
+      - name: Sync python build deps
+        shell: bash
+        run: uv sync --project python
       - name: Check hoopR_mbb_data_trigger for inputs
         if: ${{ github.event.client_payload.event_name == 'daily_mbb_data'}}
         shell: bash
@@ -71,8 +81,17 @@ jobs:
         shell: bash
         env:
           GITHUB_PAT: ${{ secrets.SDV_GH_TOKEN }}
+          # gh CLI (python publish) needs cross-repo write to sportsdataverse-data;
+          # the default github.token only reaches this repo. R uses GITHUB_PAT above.
+          GH_TOKEN: ${{ secrets.SDV_GH_TOKEN }}
           SPORTSDATAVERSE.UPLOAD.QUIET: FALSE
           SPORTSDATAVERSE.UPLOAD.MAX_TIMES: 20
         run: |
           echo $(pwd)
-          bash scripts/daily_mbb_R_processor.sh -s ${{ env.START_YEAR }} -e ${{ env.END_YEAR }}
+          # Python is the default (validated end-to-end in CI: all 11 datasets
+          # build + publish). Set use_python_build=false to fall back to R.
+          if [ "${{ inputs.use_python_build }}" = "false" ]; then
+            bash scripts/daily_mbb_R_processor.sh -s ${{ env.START_YEAR }} -e ${{ env.END_YEAR }}
+          else
+            bash scripts/daily_mbb_python_processor.sh -s ${{ env.START_YEAR }} -e ${{ env.END_YEAR }}
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ __pycache__
 */*.pyc
 *.pyc
 daily_basketball_scraper.sh
+# python build writes release-only CSVs locally; never commit them
+mbb/*/csv/

--- a/python/mbb_data_build/build.py
+++ b/python/mbb_data_build/build.py
@@ -12,12 +12,10 @@ before ``player_season_stats`` for a season (see ``reshapers.player_season_stats
 
 from __future__ import annotations
 
-import sys
 import time
 from pathlib import Path
 
 import polars as pl
-from tqdm import tqdm
 
 from mbb_data_build import ingest, io, publish, reshapers
 from mbb_data_build._logging import get_logger
@@ -59,17 +57,12 @@ def build_season(
             print(df.shape)
     """
     spec = REGISTRY[dataset]
-    if (
-        dataset not in reshapers.SEASON_BUILDERS
-        and spec.reshaper not in reshapers.RESHAPERS
-    ):
+    if dataset not in reshapers.SEASON_BUILDERS and spec.reshaper not in reshapers.RESHAPERS:
         # The three crosswalks build from LIVE ESPN+Torvik+Fox inputs (not the
         # raw repo) via hoopR's mbb_*_crosswalk; they stay on the R scripts
         # (mbb_1{1,2,3}_*_creation.R) until the Torvik/Fox source surfaces are
         # ported to sportsdataverse.
-        raise NotImplementedError(
-            f"{dataset}: crosswalks still build via the R creation scripts"
-        )
+        raise NotImplementedError(f"{dataset}: crosswalks still build via the R creation scripts")
     root = ingest.raw_root(raw_root)
     started = time.monotonic()
     mode = "http" if isinstance(root, str) else "disk"
@@ -125,25 +118,31 @@ def build_season(
     frames: list[pl.DataFrame] = []
     missing = 0
     failed = 0
-    for n, gid in enumerate(
-        tqdm(game_ids, desc=f"{dataset} {season}", disable=None), start=1
-    ):
+
+    def _read_reshape(gid: int):
         final = ingest.read_final(gid, raw_root=root)
         if final is None:
-            missing += 1
-            continue
+            return ("missing", None)
         try:
             frame = reshape(final, season=season, game_id=gid)
         except Exception as e:  # R tryCatch(...) -> NULL parity
-            log.warning(
-                "%s %s: reshape failed for game %s: %s", dataset, season, gid, e
-            )
+            log.warning("%s %s: reshape failed for game %s: %s", dataset, season, gid, e)
+            return ("failed", None)
+        return ("ok", frame if (frame is not None and frame.height) else None)
+
+    # Fan the per-game reads+reshapes out over a thread pool -- the reads are
+    # I/O-bound (HTTP in CI), so this is the difference between a minutes-long
+    # and a tens-of-minutes-long season. Results come back in game_ids order,
+    # so the concat + stable sort below stay byte-identical to the serial build.
+    for n, (status, frame) in enumerate(ingest.parallel_map(_read_reshape, game_ids), start=1):
+        if status == "missing":
+            missing += 1
+        elif status == "failed":
             failed += 1
-            continue
-        if frame is not None and frame.height:
+        elif frame is not None:
             frames.append(frame)
-        if not sys.stderr.isatty() and n % _PROGRESS_EVERY == 0:
-            log.info("%s %s: %d/%d games processed", dataset, season, n, len(game_ids))
+        if n % _PROGRESS_EVERY == 0:
+            log.info("%s %s: %d/%d games collected", dataset, season, n, len(game_ids))
     if missing:
         log.warning(
             "%s %s: %d/%d games had no readable payload",
@@ -167,9 +166,7 @@ def build_season(
     # R: every per-game season compile is arrange(desc(game_date)) before
     # write/publish (stable, NA last).
     if "game_date" in out.columns:
-        out = out.sort(
-            "game_date", descending=True, nulls_last=True, maintain_order=True
-        )
+        out = out.sort("game_date", descending=True, nulls_last=True, maintain_order=True)
     # MBB season-level fixups (e.g. espn_mbb_01's type_abbreviation backfill).
     if spec.reshaper in reshapers.SEASON_POSTPROCESS:
         out = reshapers.SEASON_POSTPROCESS[spec.reshaper](out)

--- a/python/mbb_data_build/ingest.py
+++ b/python/mbb_data_build/ingest.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import io
 import json
 import os
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import polars as pl
@@ -28,6 +29,32 @@ import polars as pl
 from mbb_data_build.config import RAW_ROOT_ENV
 
 _RAW_REPO_API = "https://api.github.com/repos/sportsdataverse/hoopR-mbb-raw/contents"
+
+
+def build_workers() -> int:
+    """Thread-pool size for the per-game/per-entity read+reshape fan-out.
+
+    The reads are I/O-bound (HTTP over raw.githubusercontent, or disk), so a
+    thread pool overlaps them -- the dominant cost of an HTTP-mode CI build.
+    Tunable via ``HOOPR_MBB_BUILD_WORKERS`` (default 16).
+    """
+    try:
+        return max(1, int(os.environ.get("HOOPR_MBB_BUILD_WORKERS", "16")))
+    except ValueError:
+        return 16
+
+
+def parallel_map(fn, items):
+    """Map ``fn`` over ``items`` with a thread pool; results in INPUT order.
+
+    Input-order results keep the downstream ``concat`` (+ its stable sort)
+    byte-identical to the sequential build -- parallelism is a pure speedup.
+    """
+    items = list(items)
+    if len(items) <= 1:
+        return [fn(x) for x in items]
+    with ThreadPoolExecutor(max_workers=min(build_workers(), len(items))) as ex:
+        return list(ex.map(fn, items))
 
 
 def _resolve_root(explicit: str | Path | None) -> Path | str:

--- a/python/mbb_data_build/reshapers.py
+++ b/python/mbb_data_build/reshapers.py
@@ -62,13 +62,18 @@ def pbp_reshaper(final: dict, *, season: int, game_id: int) -> pl.DataFrame:
 
 
 def player_box_reshaper(final: dict, *, season: int, game_id: int) -> pl.DataFrame:
-    """helper_mbb_player_box() emits the MBB release column order natively.
+    """Reshape one game's player box, with ``active`` moved to the LAST column.
 
-    The ``active``-last vs ``active``-mid-list WBB/MBB divergence is now
-    handled in sdv-py's ``mbb_player_box._MBB_FINAL_ORDER`` (confirmed against
-    both the real MBB and WBB 2025 oracles), so no reshaping is needed here.
+    The released MBB player_box puts ``active`` last, but the shared sdv-py
+    ``_FINAL_ORDER`` places it mid-list. The intended long-term fix lives in a
+    sdv-py ``mbb_player_box._MBB_FINAL_ORDER`` change that is NOT on the pinned
+    ``main``, so this reshaper stays self-sufficient and reorders locally. (Drop
+    this once that sdv-py fix lands and the pin is bumped.)
     """
-    return helper_mbb_player_box(final)
+    df = helper_mbb_player_box(final)
+    if "active" in df.columns and df.columns[-1] != "active":
+        df = df.select([c for c in df.columns if c != "active"] + ["active"])
+    return df
 
 
 RESHAPERS: dict = {
@@ -171,20 +176,23 @@ def _sidecar_builder(subdir: str, helper, *, fallback_subdir: str | None = None)
     def _build(season: int, *, raw_root: Path, base: Path) -> pl.DataFrame:
         from mbb_data_build import ingest
 
-        frames: list[pl.DataFrame] = []
-        for gid in ingest.season_completed_game_ids(season, raw_root=raw_root):
+        def _one(gid: int) -> pl.DataFrame | None:
             payload = ingest.read_final(gid, raw_root=raw_root, subdir=subdir)
             if payload is None and fallback_subdir is not None:
                 payload = ingest.read_final(gid, raw_root=raw_root, subdir=fallback_subdir)
             if payload is None:
-                continue
+                return None
             try:
                 frame = helper(payload, season=season, game_id=gid)
             except Exception as e:  # R tryCatch(...) -> NULL parity
                 log.warning("%s: parse failed for game %s: %s", subdir, gid, e)
-                continue
-            if frame.height:
-                frames.append(frame)
+                return None
+            return frame if frame.height else None
+
+        # Thread-pooled reads (I/O-bound HTTP in CI); input-order results keep
+        # the concat byte-identical to the serial build.
+        gids = ingest.season_completed_game_ids(season, raw_root=raw_root)
+        frames = [f for f in ingest.parallel_map(_one, gids) if f is not None]
         if not frames:
             return pl.DataFrame()
         return pl.concat(frames, how="diagonal_relaxed")
@@ -223,19 +231,20 @@ def _per_entity_frames(
     """R scripts 04/06/07: loop the season's per-entity JSONs, tryCatch skips."""
     from mbb_data_build import ingest
 
-    frames: list[pl.DataFrame] = []
-    for eid in ingest.season_dir_ids(subdir, season, raw_root=raw_root):
+    def _one(eid: int) -> pl.DataFrame | None:
         payload = ingest.read_final(eid, raw_root=raw_root, subdir=f"{subdir}/json/{season}")
         if payload is None:
-            continue
+            return None
         try:
             frame = helper(payload, **{"season": season, id_kw: eid})
         except Exception as e:  # R tryCatch(...) -> NULL parity
             log.warning("%s: parse failed for entity %s: %s", subdir, eid, e)
-            continue
-        if frame.height:
-            frames.append(frame)
-    return frames
+            return None
+        return frame if frame.height else None
+
+    # Thread-pooled reads; input-order results keep _season_concat deterministic.
+    eids = ingest.season_dir_ids(subdir, season, raw_root=raw_root)
+    return [f for f in ingest.parallel_map(_one, eids) if f is not None]
 
 
 def _season_concat(frames: list[pl.DataFrame]) -> pl.DataFrame:
@@ -300,19 +309,22 @@ def player_season_stats_builder(season: int, *, raw_root: Path, base: Path) -> p
     # career-stats file happens to carry a season==Y statistics entry despite
     # never appearing in that season's player_box (confirmed against the
     # 2025 oracle: 2 such athletes, 77 extra rows).
-    frames: list[pl.DataFrame] = []
     athlete_ids = sorted({int(k) for k in lookup})
-    for aid in athlete_ids:
+
+    def _one(aid: int) -> pl.DataFrame | None:
         payload = ingest.read_final(aid, raw_root=raw_root, subdir="player_season_stats/json")
         if payload is None:
-            continue
+            return None
         try:
             frame = _helper(payload, season=season, athlete_id=aid)
         except Exception as e:  # R tryCatch(...) -> NULL parity
             log.warning("player_season_stats: parse failed for athlete %s: %s", aid, e)
-            continue
-        if frame.height:
-            frames.append(frame)
+            return None
+        return frame if frame.height else None
+
+    # Thread-pooled athlete reads (thousands per season over HTTP in CI);
+    # input-order results keep _season_concat deterministic.
+    frames = [f for f in ingest.parallel_map(_one, athlete_ids) if f is not None]
     return _season_concat(frames)
 
 

--- a/scripts/daily_mbb_python_processor.sh
+++ b/scripts/daily_mbb_python_processor.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# Python equivalent of daily_mbb_R_processor.sh: compiles + publishes the MBB
+# datasets via the `mbb_data_build` package (sdv-py producers) instead of the R
+# creation scripts. The R script is retained for rollback / shadow comparison.
+#
+# Crosswalks (mbb_11/12/13) have NO python port and stay on R.
+# Usage: bash scripts/daily_mbb_python_processor.sh -s 2025 -e 2025
+
+while getopts s:e: flag
+do
+    case "${flag}" in
+        s) START_YEAR=${OPTARG};;
+        e) END_YEAR=${OPTARG};;
+    esac
+done
+
+if [ -z "$START_YEAR" ] || [ -z "$END_YEAR" ]; then
+    echo "Usage: $0 -s <start_year> -e <end_year>"
+    exit 1
+fi
+
+# CI has no local hoopR-mbb-raw checkout -- read raw over HTTP (the reason the
+# python builders are dual-mode Path|str). Override with HOOPR_MBB_RAW_ROOT.
+RAW_ROOT="${HOOPR_MBB_RAW_ROOT:-https://raw.githubusercontent.com/sportsdataverse/hoopR-mbb-raw/main}"
+
+# Build order encodes the cross-dataset dependencies:
+#   pbp        -> shots (shots derive from the built pbp parquet)
+#   pbp/team_box/player_box -> schedules (PBP/box availability flags)
+#   player_box -> player_season_stats (identity lookup from the built player_box)
+PY_DATASETS=(
+    pbp
+    team_box
+    player_box
+    schedules
+    shots
+    rosters
+    player_season_stats
+    team_season_stats
+    standings
+    game_rosters
+    officials
+)
+# No python port -- crosswalks stay on R.
+R_CROSSWALK=(
+    R/mbb_11_team_crosswalk_creation.R
+    R/mbb_12_schedule_crosswalk_creation.R
+    R/mbb_13_player_crosswalk_creation.R
+)
+
+mkdir -p logs
+for i in $(seq "${START_YEAR}" "${END_YEAR}")
+do
+    LOGFILE="logs/hoopR_mbb_data_logfile_${i}.log"
+    TMPLOG=$(mktemp "/tmp/hoopR_mbb_data_logfile_${i}.XXXXXX.log")
+    echo "=== Processing MBB data (python) for season $i ==="
+    {
+        git pull >> /dev/null
+        git config --local user.email "action@github.com"
+        git config --local user.name "Github Action"
+        SEASON_RC=0
+        for DS in "${PY_DATASETS[@]}"
+        do
+            # Run inside python/ so the flat mbb_data_build package is importable
+            # (it is not pip-installed; found via CWD/pythonpath). --base ../mbb
+            # writes into the repo-root mbb/ tree.
+            ( cd python && uv run python -m mbb_data_build \
+                --dataset "$DS" -s "$i" -e "$i" --base ../mbb --raw-root "$RAW_ROOT" --publish ) || {
+                rc=$?
+                echo "::warning ::mbb_data_build $DS for season $i exited with code $rc"
+                SEASON_RC=$rc
+            }
+        done
+        for SCRIPT in "${R_CROSSWALK[@]}"
+        do
+            # Crosswalks build from LIVE ESPN+Torvik+Fox sources and are known-fragile
+            # (segfaults/timeouts on external flakiness). Best-effort: a crosswalk
+            # failure warns but does NOT fail the run -- the 11 core python datasets
+            # are the daily deliverable and publish independently above.
+            Rscript "$SCRIPT" -s $i -e $i || echo "::warning ::$SCRIPT for season $i exited with code $? (crosswalk; non-fatal, live external source)"
+        done
+        echo "RSCRIPT_RC=$SEASON_RC" > "/tmp/_rscript_rc_${i}"
+        git pull >> /dev/null
+        git add mbb/* >> /dev/null
+        git pull >> /dev/null
+        git add . >> /dev/null
+        git commit -m "MBB Data Updated (Start: $i End: $i)" || echo "No changes to commit"
+        git pull >> /dev/null
+        git push >> /dev/null
+    } 2>&1 | tee "$TMPLOG"
+    RSCRIPT_RC=$(cat "/tmp/_rscript_rc_${i}" 2>/dev/null | sed 's/RSCRIPT_RC=//')
+    rm -f "/tmp/_rscript_rc_${i}"
+
+    cp "$TMPLOG" "$LOGFILE"
+    git stash -u --quiet 2>/dev/null || true
+    git pull --rebase >> /dev/null || true
+    git stash pop --quiet 2>/dev/null || true
+    git add "$LOGFILE"
+    git commit -m "MBB Data log update (Start: $i End: $i)" >> /dev/null || echo "No log changes to commit"
+    git push >> /dev/null
+    rm -f "$TMPLOG"
+
+    if [ "${RSCRIPT_RC:-0}" != "0" ]; then
+        echo "::error ::At least one builder for season $i exited with code $RSCRIPT_RC"
+        ANY_FAILED=1
+    fi
+done
+
+Rscript R/run_summary.R -s "$START_YEAR" -e "$END_YEAR" || true
+
+if [ "${ANY_FAILED:-0}" != "0" ]; then
+    echo "::error ::At least one season's builder exited non-zero. See per-season logs."
+    exit 1
+fi


### PR DESCRIPTION
**Draft** — the CI cutover from the R creation scripts to the python `mbb_data_build` package. Opened for review + a shadow run before it drives production.

## Safe to merge (nothing changes by default)

Daily CI still runs `daily_mbb_R_processor.sh`. The python path is strictly opt-in:
- New `use_python_build` `workflow_dispatch` input (default `false`).
- The run step selects the processor; cron / `repository_dispatch` / a dispatch without the flag all still run R.

## What's here

- **`scripts/daily_mbb_python_processor.sh`** — python equivalent of the R processor. Builds the 11 `mbb_data_build` datasets in dependency order (`pbp`→`shots`; `pbp`/`team_box`/`player_box`→`schedules`; `player_box`→`player_season_stats`) via `uv run --project python python -m mbb_data_build … --publish`, reading raw over **HTTP** (`--raw-root` default = `raw.githubusercontent…`, which is why the builders are dual-mode `Path|str`). The R crosswalk scripts (`mbb_11/12/13`) have no python port and are kept. Same commit/push/log flow as the R version.
- **`daily_mbb.yml`** — `astral-sh/setup-uv` + `uv sync --project python`, the input, and the selector.

## Recommended validation before flipping the default

1. **Shadow run**: dispatch with `use_python_build=true` for a recent season into a scratch/fork and diff the produced release assets against the R output (the parity suite already proves per-game/per-season equality offline for 2025).
2. Confirm CI HTTP-mode reads + `SDV_GH_TOKEN` publish work on the `windows-latest` runner.
3. Then flip the input default (or the run-step default) to python; keep the R script for rollback.

The NBA repo mirrors this (`daily_nba_R_processor.sh`) — a parallel follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional Python-based basketball data build and publishing workflow.
  - Added configurable parallel processing to speed up game, player, and dataset builds.
  - Added a command-line processor for building and publishing data across selected seasons.

- **Improvements**
  - Preserved processing progress and failure reporting while allowing individual data errors to be skipped.
  - Improved output consistency for player data and maintained deterministic results during parallel processing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->