### PR TITLE
build(deps): re-sync sportsdataverse pin to main (MBB player_box active-last)

### DIFF
--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1480,7 +1480,7 @@ wheels = [
 [[package]]
 name = "sportsdataverse"
 version = "0.0.71"
-source = { git = "https://github.com/sportsdataverse/sportsdataverse-py?branch=main#f4d6523bb790da9f4681f07a455bdc1ad5591124" }
+source = { git = "https://github.com/sportsdataverse/sportsdataverse-py?branch=main#f738f1bab86823b8669ea2ca5762e4229df03524" }
 dependencies = [
     { name = "attrs" },
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Re-syncs the `sportsdataverse` git-main pin in `python/uv.lock` from `f4d6523b` → `f738f1ba`.

**Why:** the reshaper's `active`-column reorder hack was already removed on main (deferring the MBB `active`-last vs WBB `active`-mid-list divergence to `sportsdataverse.mbb.mbb_player_box._MBB_FINAL_ORDER`), but the pinned commit predated that sdv-py fix — so main was building/parity-testing MBB player_box against the pre-fix helper (emitting `active` mid-list). This bump pulls in the sdv-py fix (`sportsdataverse-py#260`, now on main), making the installed helper emit `active` last again.

**Verified:** with the new pin, `from sportsdataverse.mbb.mbb_player_box import _MBB_FINAL_ORDER; _MBB_FINAL_ORDER[-1] == "active"` → True. The full `tests/mbb_data_build/test_parity_player_box.py` oracle check is gated on a co-located `hoopR-mbb-raw` sibling checkout (skips without it) — it runs in CI / a full local checkout.

Only `python/uv.lock` changed (single-package upgrade).