### PR TITLE
chore(compile): drop the local player_box active reorder (sdv-py now owns it)

### DIFF
--- a/python/mbb_data_build/reshapers.py
+++ b/python/mbb_data_build/reshapers.py
@@ -62,18 +62,13 @@ def pbp_reshaper(final: dict, *, season: int, game_id: int) -> pl.DataFrame:
 
 
 def player_box_reshaper(final: dict, *, season: int, game_id: int) -> pl.DataFrame:
-    """Reshape one game's player box, with ``active`` moved to the LAST column.
+    """helper_mbb_player_box() emits the MBB release column order natively.
 
-    The released MBB player_box puts ``active`` last, but the shared sdv-py
-    ``_FINAL_ORDER`` places it mid-list. The intended long-term fix lives in a
-    sdv-py ``mbb_player_box._MBB_FINAL_ORDER`` change that is NOT on the pinned
-    ``main``, so this reshaper stays self-sufficient and reorders locally. (Drop
-    this once that sdv-py fix lands and the pin is bumped.)
+    The released MBB player_box orders ``active`` LAST, which sdv-py now handles
+    in ``mbb_player_box._MBB_FINAL_ORDER`` (on the pinned main), so no local
+    reordering is needed here.
     """
-    df = helper_mbb_player_box(final)
-    if "active" in df.columns and df.columns[-1] != "active":
-        df = df.select([c for c in df.columns if c != "active"] + ["active"])
-    return df
+    return helper_mbb_player_box(final)
 
 
 RESHAPERS: dict = {


### PR DESCRIPTION
Follow-up cleanup. The reshaper reordered `active` last locally because sdv-py's `mbb_player_box._MBB_FINAL_ORDER` fix wasn't on the pinned main. It has since landed and the lock resolves to it (`f738f1ba` = sdv-py main), so `helper_mbb_player_box` emits `active` last natively (verified: idx 54/55). The local reorder is now a redundant no-op with a stale docstring — removed, back to a clean delegate.

Parity suite unchanged: **37 passed**.