### PR TITLE
feat(compile): add player_core dataset (athlete identity + bio)

### DIFF
--- a/python/mbb_data_build/config.py
+++ b/python/mbb_data_build/config.py
@@ -74,9 +74,7 @@ class DatasetSpec:
 
 REGISTRY: dict[str, DatasetSpec] = {
     "pbp": DatasetSpec("pbp", "play_by_play", _T + "pbp", "pbp", write_tree_csv=False),
-    "schedules": DatasetSpec(
-        "schedules", "mbb_schedule", _T + "schedules", "schedules"
-    ),
+    "schedules": DatasetSpec("schedules", "mbb_schedule", _T + "schedules", "schedules"),
     "shots": DatasetSpec(
         "shots",
         "shots",
@@ -108,6 +106,21 @@ REGISTRY: dict[str, DatasetSpec] = {
         "player_season_stats",
         # NB: no {season} segment -- the raw payload is flat/full-career.
         manifest_endpoint=_RAW + "/player_season_stats/json/<athlete_id>.json",
+    ),
+    # Athlete identity + bio. NEW dataset -- no R creation script exists, and
+    # nothing published this before: the player_season_stats payload carries no
+    # identity at all (not even the athlete id -- only the filename does).
+    # Raw is flat/athlete-keyed (a core record is per-athlete, and the core-v2
+    # athlete resource takes no season param), so no {season} segment; "who
+    # played in season Y" comes from the built player_box.
+    "player_core": DatasetSpec(
+        "player_core",
+        "player_core",
+        _T + "player_core",
+        "player_core",
+        # NO manifest_endpoint: a manifest is the contract for an R
+        # load_mbb_<ds>_manifest() loader, and player_core has no loader yet --
+        # manifesting it would publish an asset nothing reads.
     ),
     "team_season_stats": DatasetSpec(
         "team_season_stats",

--- a/python/mbb_data_build/reshapers.py
+++ b/python/mbb_data_build/reshapers.py
@@ -323,6 +323,70 @@ def player_season_stats_builder(season: int, *, raw_root: Path, base: Path) -> p
     return _season_concat(frames)
 
 
+def player_core_builder(season: int, *, raw_root: Path, base: Path) -> pl.DataFrame:
+    """Athlete identity + bio for the athletes who appeared in ``season``.
+
+    The raw tree is flat (``player_core/json/<athlete_id>.json``, one record per
+    athlete -- the core-v2 athlete resource takes no season param), so "who
+    played in season Y" comes from the season's already-built player_box.
+    Requires player_box to have been built first under ``base``.
+
+    What the season partition MEANS here: "the athletes who appeared in season
+    Y, with their CURRENT bio". The season dimension is participation -- it is
+    NOT the bio's vintage. ESPN overwrites height/weight/jersey in place, so
+    era-correct bio is not obtainable from any ESPN endpoint, and
+    ``current_team_id`` is the athlete's team TODAY, not their season team
+    (that lives in player_box / player_season_stats). See
+    ``sportsdataverse.nba.nba_player_core``.
+    """
+    from sportsdataverse.mbb import helper_mbb_player_core
+
+    from mbb_data_build import ingest
+
+    pb_path = base / "player_box" / "parquet" / f"player_box_{season}.parquet"
+    if not pb_path.exists():
+        log.warning(
+            "player_core %s: no built player_box parquet at %s -- cannot resolve "
+            "which athletes played this season (build player_box first)",
+            season,
+            pb_path,
+        )
+        return pl.DataFrame()
+    # Only the ID SET is needed, not identity columns -- player_core *is* the
+    # identity source. So this reads athlete_id straight off player_box rather
+    # than going through an identity lookup (those exist to graft identity onto
+    # the identity-less player_season_stats payload). It also keeps this builder
+    # identical across all four leagues: wnba/wbb have no player_box-based
+    # lookup, only a team_rosters-based one -- and team_rosters is exactly the
+    # source ESPN cannot serve historically.
+    athlete_ids = sorted(
+        {int(a) for a in pl.read_parquet(pb_path, columns=["athlete_id"])["athlete_id"].drop_nulls().unique()}
+    )
+
+    def _one(aid: int) -> pl.DataFrame | None:
+        payload = ingest.read_final(aid, raw_root=raw_root, subdir="player_core/json")
+        if payload is None:
+            return None
+        try:
+            frame = helper_mbb_player_core(payload, athlete_id=aid)
+        except Exception as e:  # tryCatch(...) -> NULL parity with the sibling builders
+            log.warning("player_core: parse failed for athlete %s: %s", aid, e)
+            return None
+        return frame if frame.height else None
+
+    # Thread-pooled athlete reads (tens of thousands per season over HTTP in CI);
+    # input-order results keep _season_concat deterministic.
+    frames = [f for f in ingest.parallel_map(_one, athlete_ids) if f is not None]
+    out = _season_concat(frames)
+    if out.is_empty():
+        return out
+    # The helper is a pure athlete projection (it deliberately takes no season --
+    # a core record is not season data). The season column belongs to the
+    # PARTITION, so the builder stamps it, keeping the released frame
+    # self-describing when seasons are concatenated.
+    return out.select(pl.lit(season, dtype=pl.Int32).alias("season"), pl.all())
+
+
 def standings_builder(season: int, *, raw_root: Path, base: Path) -> pl.DataFrame:
     from sportsdataverse.mbb import helper_mbb_standings
 
@@ -345,6 +409,7 @@ SEASON_BUILDERS: dict = {
     "rosters": rosters_builder,
     "team_season_stats": team_season_stats_builder,
     "player_season_stats": player_season_stats_builder,
+    "player_core": player_core_builder,
     "standings": standings_builder,
 }
 


### PR DESCRIPTION
Compiles the new `mbb/player_core` raw tree into `player_core_{season}.parquet` via `sportsdataverse.mbb.helper_mbb_player_core` (**depends on [sportsdataverse-py#270](https://github.com/sportsdataverse/sportsdataverse-py/pull/270)**).

**Why the dataset exists:** `player_season_stats` carries **no athlete identity at all** — no name, no bio, **not even the athlete id** (only the filename does). Its `"height"` keys are team-logo pixel heights; its `"fullName"` keys are arena names. This is the pipeline's first source of athlete bio.

## Builder
Mirrors `player_season_stats_builder`: the raw tree is **flat** (`player_core/json/<athlete_id>.json` — a core record is per-athlete, and the core-v2 athlete resource takes no season param), so *"who played in season Y"* comes from the season's **already-built player_box**.

It reads `athlete_id` straight off player_box rather than via an identity lookup — **player_core *is* the identity source**, so only the id set is needed. That also keeps the builder identical across all four leagues: wnba/wbb have no player_box-based lookup, only a **team_rosters**-based one — and team_rosters is exactly the source ESPN cannot serve historically.

## What the season partition means
**"The athletes who appeared in season Y, with their CURRENT bio."** The season dimension is *participation*, not the bio's vintage — ESPN overwrites height/weight/jersey in place, so era-correct bio is unobtainable from any ESPN endpoint, and `current_team_id` is the athlete's team **today**, not their season team. The sdv-py helper deliberately takes no `season`; the builder stamps the partition's.

## No manifest — on purpose
A manifest is the contract for an R `load_mbb_<ds>_manifest()` loader, and player_core has no loader yet, so manifesting it would **publish an asset nothing reads**. The repo's existing *"exactly the R-manifested datasets have a manifest"* test caught me adding one — good test.

## Verified
Builds a real season end-to-end against the committed raw tree, and the full suite passes.

Release tag `espn_mens_college_basketball_player_core` **does not exist yet** — creating it, and the matching R loader, is a separate deliberate decision.