### PR TITLE
feat(models): add mbb_ratings + mbb_player_value dataset publishers

### DIFF
--- a/.github/workflows/mbb_models_cron.yml
+++ b/.github/workflows/mbb_models_cron.yml
@@ -1,0 +1,107 @@
+name: MBB Model Datasets
+
+# Refreshes the `mbb_ratings` + `mbb_player_value` dataset releases on
+# sportsdataverse-data: opponent-adjusted team ratings and per-player box
+# Plus/Minus, built by sdv-py's `mbb_team_ratings()` / `mbb_box_bpm()` over
+# the released ESPN schedule + boxscores (this job reads releases, it does
+# not scrape).
+#
+# Credential scoping: the cross-repo publish PAT (SDV_GH_TOKEN) is NOT
+# exported job-wide; it is set only on the build+publish steps.
+
+on:
+  workflow_dispatch:
+    inputs:
+      seasons:
+        description: 'Season or inclusive range, hoopR end-year convention (e.g. 2026 or 2002:2026). Default: the current season.'
+        required: false
+        type: string
+      dry_run:
+        description: 'Build only; plan the uploads without publishing'
+        required: false
+        type: boolean
+        default: false
+  schedule:
+    # Daily in the MBB season window (Nov - early Apr), after the daily data
+    # builds land.
+    - cron: '0 13 * 11,12 *'   # November-December
+    - cron: '0 13 * 1-4 *'     # January-April (through the tournament)
+
+permissions:
+  contents: read
+
+env:
+  PUBLISH_REPO: sportsdataverse/sportsdataverse-data
+
+jobs:
+  models:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: python
+    steps:
+      - name: Checkout mbb-data
+        uses: actions/checkout@v5
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: python/uv.lock
+
+      - name: Sync deps
+        run: uv sync --frozen
+
+      # Canary: this repo pins sportsdataverse to git@main via tool.uv.sources,
+      # so a plain sync carries the model surface -- but fail loudly here if a
+      # re-pin ever drops it, instead of the publish dying minutes in.
+      - name: Verify the model surfaces import
+        run: |
+          uv run --no-sync python -c "
+          from sportsdataverse.mbb.mbb_team_ratings import mbb_team_ratings
+          from sportsdataverse.mbb import mbb_box_bpm
+          import importlib.metadata as md
+          print('mbb model surface OK (sportsdataverse', md.version('sportsdataverse'), ')')
+          "
+
+      # hoopR end-year convention: the 2025-26 season is 2026, so Nov/Dec
+      # belong to calendar year + 1 and Jan-Apr to the calendar year itself.
+      - name: Resolve seasons
+        env:
+          # Via env, not `${{ }}` inline in the script: a dispatch input
+          # interpolated straight into `run:` is a shell-injection sink.
+          SEASONS_INPUT: ${{ inputs.seasons }}
+        run: |
+          if [ -n "$SEASONS_INPUT" ]; then
+            SEASONS="$SEASONS_INPUT"
+          else
+            SEASONS=$(date -u +%Y)
+            M=$(date -u +%m)
+            if [ "$M" = "11" ] || [ "$M" = "12" ]; then
+              SEASONS=$((SEASONS + 1))
+            fi
+          fi
+          echo "SEASONS=$SEASONS" >> $GITHUB_ENV
+          echo "building mbb model datasets for seasons: $SEASONS"
+
+      - name: Build + publish mbb_ratings ${{ env.SEASONS }}
+        env:
+          GH_TOKEN: ${{ secrets.SDV_GH_TOKEN }}
+        run: |
+          uv run --no-sync python -m mbb_model_publish ratings \
+            --seasons "$SEASONS" \
+            --out out/mbb_ratings \
+            --tag mbb_ratings \
+            --repo "$PUBLISH_REPO" \
+            ${{ inputs.dry_run && '--dry-run' || '' }}
+
+      - name: Build + publish mbb_player_value ${{ env.SEASONS }}
+        env:
+          GH_TOKEN: ${{ secrets.SDV_GH_TOKEN }}
+        run: |
+          uv run --no-sync python -m mbb_model_publish player-value \
+            --seasons "$SEASONS" \
+            --out out/mbb_player_value \
+            --tag mbb_player_value \
+            --repo "$PUBLISH_REPO" \
+            ${{ inputs.dry_run && '--dry-run' || '' }}

--- a/python/mbb_model_publish/__init__.py
+++ b/python/mbb_model_publish/__init__.py
@@ -1,0 +1,1 @@
+"""MBB model-dataset publisher: builds + uploads `mbb_ratings` / `mbb_player_value` release assets."""

--- a/python/mbb_model_publish/__main__.py
+++ b/python/mbb_model_publish/__main__.py
@@ -1,0 +1,3 @@
+from mbb_model_publish.cli import main
+
+raise SystemExit(main())

--- a/python/mbb_model_publish/artifacts.py
+++ b/python/mbb_model_publish/artifacts.py
@@ -1,0 +1,82 @@
+"""Release-asset uploads via the gh CLI (pattern path, copied from the family template)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+GH_TIMEOUT_SECONDS = 300
+
+# Release-notes body used when auto-creating a missing release. Keyed by tag;
+# falls back to a generic note for any other tag.
+_RELEASE_BODY = {
+    "mbb_ratings": (
+        "Men's college basketball opponent-adjusted team ratings, one row per "
+        "team per season: AdjO/AdjD/AdjEM/AdjTempo with dense ranks and an "
+        "AdjEM z-score. Built by sdv-py `mbb_team_ratings()` over the released "
+        "ESPN schedule + team boxscores."
+    ),
+    "mbb_player_value": (
+        "Men's college basketball per-player-season box Plus/Minus "
+        "(offense/defense/total, team-constrained so minutes-weighted player "
+        "scores sum to the team's adjusted efficiency margin). Built by sdv-py "
+        "`mbb_box_bpm()` over the released ESPN player boxscores."
+    ),
+}
+
+
+def _gh_runner(args: list) -> None:
+    subprocess.run(["gh", *args], check=True, timeout=GH_TIMEOUT_SECONDS)
+
+
+def _gh_release_exists(tag: str, repo: str) -> bool:
+    """True if a GitHub release for ``tag`` already exists on ``repo``."""
+    r = subprocess.run(
+        ["gh", "release", "view", tag, "--repo", repo],
+        capture_output=True,
+        timeout=GH_TIMEOUT_SECONDS,
+    )
+    return r.returncode == 0
+
+
+def upload_artifacts(
+    artifacts_dir,
+    tag: str,
+    repo: str,
+    *,
+    pattern: str,
+    dry_run: bool = False,
+    runner=None,
+    exists_check=None,
+) -> dict:
+    """Upload ``artifacts_dir.glob(pattern)`` (sorted) to the ``tag`` release.
+
+    The release is created if it does not already exist (``gh release upload``
+    does not create one), so a single call is self-sufficient. Uploads are one
+    ``gh release upload`` per file with ``--clobber`` -- never a multi-file
+    glob, which silently drops large assets. ``runner`` and ``exists_check``
+    are injectable for hermetic testing.
+    """
+    run = runner or _gh_runner
+    exists = exists_check or _gh_release_exists
+    files = sorted(Path(artifacts_dir).glob(pattern))
+    created_release = False
+    if dry_run:
+        print(f"[dry-run] would ensure release {repo}:{tag} exists")
+    elif not exists(tag, repo):
+        body = _RELEASE_BODY.get(tag, f"{tag} (auto-created by mbb_model_publish).")
+        run(["release", "create", tag, "--repo", repo, "--title", tag, "--notes", body])
+        created_release = True
+    uploaded = 0
+    for f in files:
+        if dry_run:
+            print(f"[dry-run] would upload {f} -> {repo}:{tag}")
+            continue
+        run(["release", "upload", tag, str(f), "--repo", repo, "--clobber"])
+        uploaded += 1
+    return {
+        "uploaded": uploaded,
+        "files": [str(f) for f in files],
+        "tag": tag,
+        "created_release": created_release,
+    }

--- a/python/mbb_model_publish/builders.py
+++ b/python/mbb_model_publish/builders.py
@@ -1,0 +1,162 @@
+"""Build the MBB model-dataset parquet for the sportsdataverse-data release tags.
+
+Thin orchestration over the ``sportsdataverse.mbb`` compute surface, mirroring
+the cfb/pwhl `*_model_publish` builders:
+
+* :func:`build_ratings` -> one ``mbb_ratings_{season}.parquet`` per season
+  (``mbb_team_ratings``: AdjO/AdjD/AdjEM/AdjTempo per team-season).
+* :func:`build_player_value` -> one ``mbb_player_value_{season}.parquet`` per
+  season (``mbb_box_bpm``: per-player-season box Plus/Minus).
+
+Both compute fns load the released ESPN inputs themselves (schedule + team
+boxscores / player boxscores), so the builder needs no local data tree and is
+GH-Actions friendly.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+# The released ESPN MBB boxscore assets start at 2002.
+MIN_SEASON = 2002
+
+
+def _build_seasonal(
+    seasons: list[int],
+    out_dir,
+    *,
+    stem: str,
+    compute,
+) -> list[dict]:
+    """Shared season loop: compute -> refuse-empty -> write ``{stem}_{season}.parquet``."""
+    too_old = [s for s in seasons if s < MIN_SEASON]
+    if too_old:
+        raise ValueError(f"{stem}: seasons {too_old} predate the {MIN_SEASON} ESPN boxscore floor")
+
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    results: list[dict] = []
+    for season in seasons:
+        df = compute(season)
+        if df.height == 0:
+            raise ValueError(
+                f"{stem}: season {season} produced 0 rows -- refusing to publish an empty tag"
+            )
+        path = out_dir / f"{stem}_{season}.parquet"
+        df.write_parquet(path)
+        results.append({"season": season, "rows": df.height, "path": str(path)})
+        print(f"{stem}: season={season} rows={df.height} -> {path}")
+    return results
+
+
+def build_ratings(seasons: list[int], out_dir, *, compute=None) -> list[dict]:
+    """Build per-season team ratings and write ``mbb_ratings_{season}.parquet``.
+
+    Args:
+        seasons: Seasons to build (hoopR end-year convention; one parquet per
+            season).
+        out_dir: Output directory (created if absent).
+        compute: Injectable ``mbb_team_ratings``-shaped callable, for hermetic
+            tests. Defaults to ``sportsdataverse.mbb.mbb_team_ratings`` with
+            ``league="mens"``.
+
+    Returns:
+        List of ``{"season": int, "rows": int, "path": str}`` dicts, in input
+        order.
+
+    Raises:
+        ValueError: If a season is below :data:`MIN_SEASON` or yields zero rows.
+    """
+    if compute is None:
+        from sportsdataverse.mbb.mbb_team_ratings import mbb_team_ratings
+
+        def compute(season):
+            return mbb_team_ratings(season, league="mens")
+
+    return _build_seasonal(seasons, out_dir, stem="mbb_ratings", compute=compute)
+
+
+def build_player_value(seasons: list[int], out_dir, *, compute=None) -> list[dict]:
+    """Build per-season box-BPM tables and write ``mbb_player_value_{season}.parquet``.
+
+    Args:
+        seasons: Seasons to build (hoopR end-year convention).
+        out_dir: Output directory (created if absent).
+        compute: Injectable ``mbb_box_bpm``-shaped callable, for hermetic
+            tests. Defaults to ``sportsdataverse.mbb.mbb_box_bpm`` with
+            ``league="mens"``.
+
+    Returns:
+        List of ``{"season": int, "rows": int, "path": str}`` dicts, in input
+        order.
+
+    Raises:
+        ValueError: If a season is below :data:`MIN_SEASON` or yields zero rows.
+    """
+    if compute is None:
+        from sportsdataverse.mbb import mbb_box_bpm
+
+        def compute(season):
+            return mbb_box_bpm(season, league="mens")
+
+    return _build_seasonal(seasons, out_dir, stem="mbb_player_value", compute=compute)
+
+
+def write_ratings_card(results: list[dict], out_dir) -> Path:
+    """Write the ``mbb_ratings`` model card next to the season parquet."""
+    return _write_card(
+        results,
+        out_dir,
+        tag="mbb_ratings",
+        grain="one row per team per season",
+        source=(
+            "sdv-py sportsdataverse.mbb.mbb_team_ratings(league='mens') over the "
+            "released ESPN schedule + team boxscores"
+        ),
+        notes=[
+            "AdjO/AdjD are opponent-adjusted points per 100 possessions;"
+            " adj_em = adj_o - adj_d; rank is dense on adj_em descending.",
+            "The adjustment fixed point and constants are gated in sdv-py's"
+            " T1.1 oracle suite; this tag materializes that compute unchanged.",
+        ],
+    )
+
+
+def write_player_value_card(results: list[dict], out_dir) -> Path:
+    """Write the ``mbb_player_value`` model card next to the season parquet."""
+    return _write_card(
+        results,
+        out_dir,
+        tag="mbb_player_value",
+        grain="one row per (player_id, season, team_id)",
+        source=(
+            "sdv-py sportsdataverse.mbb.mbb_box_bpm(league='mens') over the "
+            "released ESPN player boxscores"
+        ),
+        notes=[
+            "Box Plus/Minus with the team constraint: minutes-weighted player"
+            " scores sum to the team's adjusted efficiency margin (points per"
+            " 100 possessions above league average).",
+            "Coefficients are the bundled team-constrained artifact gated in"
+            " sdv-py's T1.2 oracle suite; this tag materializes that compute"
+            " unchanged.",
+        ],
+    )
+
+
+def _write_card(results, out_dir, *, tag, grain, source, notes) -> Path:
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    card = {
+        "tag": tag,
+        "grain": grain,
+        "source": source,
+        "seasons": [r["season"] for r in results],
+        "rows_by_season": {str(r["season"]): r["rows"] for r in results},
+        "notes": notes,
+    }
+    path = out_dir / f"{tag}_card.json"
+    path.write_text(json.dumps(card, indent=2) + "\n", encoding="utf-8")
+    print(f"card: {path}")
+    return path

--- a/python/mbb_model_publish/cli.py
+++ b/python/mbb_model_publish/cli.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import argparse
+
+from .artifacts import upload_artifacts
+from .builders import (
+    build_player_value,
+    build_ratings,
+    write_player_value_card,
+    write_ratings_card,
+)
+
+
+def _seasons(spec: str) -> list[int]:
+    """Parse ``2002:2026`` or ``2025`` into a season list."""
+    if ":" in spec:
+        start, end = spec.split(":", 1)
+        return list(range(int(start), int(end) + 1))
+    return [int(spec)]
+
+
+def _add_common(p: argparse.ArgumentParser, default_out: str, default_tag: str) -> None:
+    p.add_argument(
+        "--seasons",
+        required=True,
+        help="a season (2025) or an inclusive range (2002:2026); hoopR end-year convention",
+    )
+    p.add_argument("--out", default=default_out)
+    p.add_argument("--tag", default=default_tag)
+    p.add_argument("--repo", default="sportsdataverse/sportsdataverse-data")
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument(
+        "--build-only",
+        action="store_true",
+        help="write parquet + card, skip the upload",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(prog="mbb_model_publish")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    r = sub.add_parser("ratings", help="build + publish opponent-adjusted team ratings")
+    _add_common(r, "out/mbb_ratings", "mbb_ratings")
+
+    v = sub.add_parser("player-value", help="build + publish per-player box Plus/Minus")
+    _add_common(v, "out/mbb_player_value", "mbb_player_value")
+
+    return ap
+
+
+def _run(args, builder, card_writer, stem: str) -> int:
+    results = builder(_seasons(args.seasons), args.out)
+    card_writer(results, args.out)
+    total = sum(r["rows"] for r in results)
+    if args.build_only:
+        print(f"{stem}: built seasons={len(results)} rows={total} -> {args.out} (build-only)")
+        return 0
+    res = upload_artifacts(
+        args.out,
+        args.tag,
+        args.repo,
+        pattern=f"{stem}_*.*",
+        dry_run=args.dry_run,
+    )
+    created = " (created release)" if res.get("created_release") else ""
+    print(
+        f"publish: seasons={len(results)} rows={total} uploaded={res['uploaded']} "
+        f"-> {args.repo}:{res['tag']}" + created + (" (dry-run)" if args.dry_run else "")
+    )
+    return 0
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.cmd == "ratings":
+        return _run(args, build_ratings, write_ratings_card, "mbb_ratings")
+    if args.cmd == "player-value":
+        return _run(args, build_player_value, write_player_value_card, "mbb_player_value")
+    return 0

--- a/python/tests/test_model_publish.py
+++ b/python/tests/test_model_publish.py
@@ -1,0 +1,139 @@
+"""Hermetic tests for the mbb model-publish builders.
+
+The sdv-py compute seams are stubbed, so these assert *orchestration* --
+season ordering, the empty-frame refusal, the floor, the card sidecars, and
+per-file upload -- not the ratings/BPM math (gated in sdv-py's oracle suites).
+"""
+
+from __future__ import annotations
+
+import json
+
+import polars as pl
+import pytest
+
+from mbb_model_publish.artifacts import upload_artifacts
+from mbb_model_publish.builders import (
+    MIN_SEASON,
+    build_player_value,
+    build_ratings,
+    write_player_value_card,
+    write_ratings_card,
+)
+from mbb_model_publish.cli import _seasons, main
+
+
+def _fake_ratings(season: int) -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "season": [season, season],
+            "team_id": ["52", "150"],
+            "adj_o": [118.2, 112.4],
+            "adj_d": [93.5, 96.1],
+            "adj_em": [24.7, 16.3],
+            "rank": [1, 2],
+        }
+    )
+
+
+def _fake_bpm(season: int) -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "player_id": ["4433137", "4592971"],
+            "season": [season, season],
+            "team_id": ["52", "150"],
+            "box_bpm": [8.4, 6.1],
+        }
+    )
+
+
+def test_build_ratings_writes_one_parquet_per_season_in_order(tmp_path):
+    results = build_ratings([2024, 2025], tmp_path, compute=_fake_ratings)
+
+    assert [r["season"] for r in results] == [2024, 2025]
+    for season in (2024, 2025):
+        path = tmp_path / f"mbb_ratings_{season}.parquet"
+        assert path.exists()
+        assert pl.read_parquet(path)["season"].unique().to_list() == [season]
+
+
+def test_build_player_value_writes_per_season(tmp_path):
+    results = build_player_value([2025], tmp_path, compute=_fake_bpm)
+
+    assert [r["rows"] for r in results] == [2]
+    assert (tmp_path / "mbb_player_value_2025.parquet").exists()
+
+
+def test_builders_refuse_an_empty_season(tmp_path):
+    empty = pl.DataFrame(schema={"season": pl.Int64, "team_id": pl.Utf8})
+
+    with pytest.raises(ValueError, match="0 rows"):
+        build_ratings([2025], tmp_path, compute=lambda s: empty)
+    with pytest.raises(ValueError, match="0 rows"):
+        build_player_value([2025], tmp_path, compute=lambda s: empty)
+
+
+def test_builders_reject_seasons_below_the_floor(tmp_path):
+    with pytest.raises(ValueError, match=str(MIN_SEASON)):
+        build_ratings([MIN_SEASON - 1], tmp_path, compute=_fake_ratings)
+    with pytest.raises(ValueError, match=str(MIN_SEASON)):
+        build_player_value([MIN_SEASON - 1], tmp_path, compute=_fake_bpm)
+
+
+def test_cards_carry_tag_and_seasons(tmp_path):
+    r = build_ratings([2025], tmp_path, compute=_fake_ratings)
+    card = json.loads(write_ratings_card(r, tmp_path).read_text(encoding="utf-8"))
+    assert card["tag"] == "mbb_ratings"
+    assert card["rows_by_season"] == {"2025": 2}
+
+    v = build_player_value([2025], tmp_path, compute=_fake_bpm)
+    card = json.loads(write_player_value_card(v, tmp_path).read_text(encoding="utf-8"))
+    assert card["tag"] == "mbb_player_value"
+    assert card["seasons"] == [2025]
+
+
+def test_upload_pattern_selects_parquet_and_card(tmp_path):
+    (tmp_path / "mbb_ratings_2025.parquet").write_bytes(b"x")
+    (tmp_path / "mbb_ratings_card.json").write_text("{}")
+    (tmp_path / "unrelated.txt").write_text("no")
+
+    calls: list = []
+    res = upload_artifacts(
+        tmp_path,
+        "mbb_ratings",
+        "sportsdataverse/sportsdataverse-data",
+        pattern="mbb_ratings_*.*",
+        runner=lambda args: calls.append(args),
+        exists_check=lambda tag, repo: True,
+    )
+
+    names = sorted(p.rsplit("\\", 1)[-1].rsplit("/", 1)[-1] for p in res["files"])
+    assert names == ["mbb_ratings_2025.parquet", "mbb_ratings_card.json"]
+    assert res["uploaded"] == 2
+    assert all("--clobber" in c for c in calls)
+
+
+def test_seasons_parses_range_and_single():
+    assert _seasons("2025") == [2025]
+    assert _seasons("2002:2005") == [2002, 2003, 2004, 2005]
+
+
+def test_cli_build_only_writes_files_and_skips_upload(tmp_path, monkeypatch):
+    import mbb_model_publish.cli as cli
+
+    monkeypatch.setattr(
+        cli,
+        "build_ratings",
+        lambda seasons, out, **kw: build_ratings(seasons, out, compute=_fake_ratings),
+    )
+    monkeypatch.setattr(
+        cli,
+        "upload_artifacts",
+        lambda *a, **k: pytest.fail("--build-only must not upload"),
+    )
+
+    rc = main(["ratings", "--seasons", "2025", "--out", str(tmp_path), "--build-only"])
+
+    assert rc == 0
+    assert (tmp_path / "mbb_ratings_2025.parquet").exists()
+    assert (tmp_path / "mbb_ratings_card.json").exists()


### PR DESCRIPTION
## What

**Publication-plan Phase 3a (MBB half)** — materializes the shipped T1.1/T1.2 compute as dataset releases on `sportsdataverse-data`.

- `mbb_model_publish`: `build_ratings` (`mbb_team_ratings`: AdjO/AdjD/AdjEM/AdjTempo per team-season) + `build_player_value` (`mbb_box_bpm`: per-player team-constrained box Plus/Minus), one parquet per season + provenance cards. Floor 2002 (ESPN boxscore assets); refuses empty seasons so a silently-empty tag can never publish.
- `ratings` / `player-value` CLI subcommands (`--seasons/--out/--tag/--repo/--dry-run/--build-only`); per-file `gh release upload --clobber`; release bodies for tag auto-creation.
- `mbb_models_cron.yml`: daily Nov–Apr, current season via the hoopR end-year convention, `SDV_GH_TOKEN` scoped to the publish steps. Both compute fns read released ESPN assets — no scraping.

## Tests

8 hermetic tests green (stubbed compute seams — the math is gated in sdv-py's oracle suites).

## Follow-ups (not in this PR)

- sdv-py `load_mbb_ratings` / `load_mbb_player_value` loaders (bundled with the wbb loaders PR).
- One-time backfill 2002:current (data-op, no PR) after merge. WBB mirror: wehoop-wbb-data (same session).