### PR TITLE
feat(ci): build + publish player_core in the daily flow

### DIFF
--- a/scripts/daily_mbb_python_processor.sh
+++ b/scripts/daily_mbb_python_processor.sh
@@ -31,6 +31,7 @@ PY_DATASETS=(
     pbp
     team_box
     player_box
+    player_core
     schedules
     shots
     rosters


### PR DESCRIPTION
`player_core` is in the registry and its release tag is populated for **every historical season** — but the daily processor's dataset list is **hardcoded**, and never included it. The dataset would have frozen at the backfill and silently missed every new athlete from here on.

Adds it **immediately after `player_box`**: `player_core` resolves *"who played in season Y"* from the season's **built player_box parquet**, so it must run after player_box in the same pass.

Found by asking what was actually left after the backfill, rather than assuming the registry entry was enough.