### PR TITLE
fix(pbp): republish win-probability columns after the nightly build

### DIFF
--- a/python/mbb_data_build/wp_enrich.py
+++ b/python/mbb_data_build/wp_enrich.py
@@ -1,0 +1,110 @@
+"""Post-publish win-probability enrichment for the season's pbp release asset.
+
+Why this exists as a separate step rather than a pbp reshaper:
+
+* The enrichment needs the season's **team_box**, and `pbp` is built *before*
+  `team_box` (the build order in `daily_mbb_python_processor.sh` is load-bearing:
+  pbp -> shots, player_box -> player_season_stats). So it cannot run inside the
+  pbp build without inverting that order.
+* The enrichment's contract is "overwrite `play_by_play_<season>.parquet` with
+  the two WP columns appended, every original column preserved" — an operation
+  on the *published* asset, not on the in-memory frame.
+
+Without this step nothing ever calls `sportsdataverse.mbb.build_mbb_season_wp`,
+and each nightly pbp publish silently strips the WP columns off the release. That
+is exactly what happened between 2026-07-12 (columns verified present) and
+2026-08-02 (columns absent from every season), which broke the platform's
+win-probability page.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+from mbb_data_build._logging import get_logger
+from mbb_data_build.config import REGISTRY
+
+log = get_logger()
+
+WP_COLS = ("pregame_home_prob", "home_win_prob")
+
+
+def enrich_and_publish(
+    season: int,
+    *,
+    league: str = "mens",
+    repo: str = "sportsdataverse/sportsdataverse-data",
+    dry_run: bool = False,
+) -> bool:
+    """Rebuild the season's pbp with WP columns and clobber the release asset.
+
+    Returns True when the asset was republished (or would be, under dry_run).
+    Never raises: a WP failure must not fail the nightly, since the plain pbp
+    asset published moments earlier is still valid data.
+    """
+    spec = REGISTRY["pbp"]
+    try:
+        if league == "mens":
+            from sportsdataverse.mbb import build_mbb_season_wp as build
+        else:
+            from sportsdataverse.wbb import build_wbb_season_wp as build
+        frame = build(season)
+    except Exception as exc:  # noqa: BLE001 - best-effort enrichment
+        log.warning("wp %s %s: build failed (%s); release keeps plain pbp", league, season, exc)
+        return False
+
+    missing = [c for c in WP_COLS if c not in frame.columns]
+    if missing:
+        log.warning("wp %s %s: builder returned no %s; skipping publish", league, season, missing)
+        return False
+    if frame.height == 0 or frame[WP_COLS[1]].null_count() == frame.height:
+        log.warning("wp %s %s: win probability is entirely null; skipping publish", league, season)
+        return False
+
+    name = f"{spec.stem}_{season}.parquet"
+    if dry_run:
+        log.info("wp %s %s: would publish %s (%d rows)", league, season, name, frame.height)
+        return True
+
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / name
+        frame.write_parquet(path, compression="zstd")
+        res = subprocess.run(
+            ["gh", "release", "upload", spec.tag, str(path), "--clobber", "--repo", repo],
+            capture_output=True,
+            text=True,
+            timeout=1800,
+        )
+    if res.returncode != 0:
+        log.warning("wp %s %s: upload failed: %s", league, season, res.stderr.strip()[:200])
+        return False
+    log.info(
+        "wp %s %s: republished %s with %s (%d rows)",
+        league,
+        season,
+        name,
+        list(WP_COLS),
+        frame.height,
+    )
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    p = argparse.ArgumentParser(prog="mbb_data_build.wp_enrich")
+    p.add_argument("-s", "--start", type=int, required=True)
+    p.add_argument("-e", "--end", type=int, required=True)
+    p.add_argument("--league", default="mens", choices=("mens", "womens"))
+    p.add_argument("--dry-run", action="store_true")
+    a = p.parse_args(argv)
+    ok = True
+    for season in range(a.start, a.end + 1):
+        ok = enrich_and_publish(season, league=a.league, dry_run=a.dry_run) and ok
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/daily_mbb_python_processor.sh
+++ b/scripts/daily_mbb_python_processor.sh
@@ -85,6 +85,14 @@ do
         # The NBA sibling hit exactly that between its python cutover and this
         # fix; MBB only escaped it by being out of season.
         # NOT best-effort like the crosswalks: rds is the R package's contract.
+        # Win-probability enrichment: republishes play_by_play_$i.parquet with
+        # pregame_home_prob + home_win_prob appended. MUST run after the dataset
+        # loop (it needs team_box, which builds after pbp) and is best-effort --
+        # the plain pbp published above is still valid data if this fails.
+        # Without it every nightly strips the WP columns off the release, which
+        # is what broke the platform's win-probability page in 2026-08.
+        ( cd python && uv run python -m mbb_data_build.wp_enrich -s "$i" -e "$i" ) || \
+            echo "::warning ::wp_enrich for season $i exited with code $? (non-fatal; release keeps plain pbp)"
         echo "RSCRIPT_RC=$SEASON_RC" > "/tmp/_rscript_rc_${i}"
         git pull >> /dev/null
         git add mbb/* >> /dev/null


### PR DESCRIPTION
The pbp release asset has **two writers**. This repo publishes `play_by_play_<season>.parquet` as plain pbp; sdv-py's `build_mbb_season_wp` is designed to *overwrite that same asset* with `pregame_home_prob` + `home_win_prob` appended. Nothing sequenced them, and nothing outside sdv-py ever called the builder — `git log -S home_win_prob --all` here returns **nothing**.

So the enrichment ran by hand once (columns verified 2026-07-12), and every nightly pbp publish since has silently stripped it back off. By 2026-08-02 **no season carried a win-probability column at all**, breaking the platform win-probability page for MBB/WBB (sportsdataverse-data#6, sportsdataverse-web#33).

### Fix
`mbb_data_build.wp_enrich`, called from the per-season loop **after** the dataset loop. It must run there: the enrichment needs `team_box`, and `pbp` builds *before* `team_box` (that order is load-bearing for shots / player_season_stats), so this cannot be a pbp reshaper without inverting the dependency.

Guards:
- **Best-effort** — a WP failure warns rather than failing the run; the plain pbp published moments earlier is still valid data.
- **Refuses to publish an all-null frame**, so a broken model cannot quietly replace good data with empty columns.

All ten affected seasons (mbb + wbb, 2022–2026) were rebuilt and republished out of band and verified against the live release.

## Summary by Sourcery

Add a post-publish win-probability enrichment step for play-by-play release assets and integrate it into the nightly MBB Python processor as a best-effort republish.

New Features:
- Provide a wp_enrich CLI that rebuilds season play-by-play with win-probability columns and overwrites the corresponding release asset, preserving existing data.
- Support win-probability enrichment for both mens and womens leagues via the sportsdataverse season WP builders.

Bug Fixes:
- Ensure nightly builds no longer strip win-probability columns from play-by-play releases, restoring data needed by the platform win-probability pages.
- Prevent publishing of enriched assets when the win-probability model fails or returns missing/entirely null values, avoiding silent replacement of valid data with empty columns.

Enhancements:
- Make win-probability enrichment a non-fatal, best-effort step so nightly releases remain valid even if enrichment fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added post-publish win-probability enrichment for men’s and women’s basketball season data.
  * Enriched play-by-play releases now include pregame home-win indicators and home-win probabilities.
  * Added support for processing season ranges, selecting leagues, and running in dry-run mode.

* **Bug Fixes**
  * Enrichment failures no longer prevent the underlying play-by-play release from being published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->